### PR TITLE
(MINOR) Added a timestamp to the Oak PC

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1655,6 +1655,14 @@
 	.2byte \value
 	.endm
 
+	@ Stores the components of the current timestamp into provided variables
+	.macro storetimestamp hours:req, minutes:req, seconds:req
+	.byte 0x0d8
+	.2byte \hours
+	.2byte \minutes
+	.2byte \seconds
+	.endm
+
 @ Supplementary
 
 	.macro goto_if_unset flag:req, dest:req

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -217,7 +217,7 @@ gScriptCmdTable::
 	.4byte ScrCmd_setflagwithoffset              @ 0xd5
 	.4byte ScrCmd_clearflagwithoffset            @ 0xd6
 	.4byte ScrCmd_checkflagwithoffset            @ 0xd7
-	.4byte ScrCmd_storetimestamp				 @ 0xd8
+	.4byte ScrCmd_storetimestamp                 @ 0xd8
 
 gScriptCmdTableEnd::
 	.4byte ScrCmd_nop

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -217,6 +217,7 @@ gScriptCmdTable::
 	.4byte ScrCmd_setflagwithoffset              @ 0xd5
 	.4byte ScrCmd_clearflagwithoffset            @ 0xd6
 	.4byte ScrCmd_checkflagwithoffset            @ 0xd7
+	.4byte ScrCmd_storetimestamp				 @ 0xd8
 
 gScriptCmdTableEnd::
 	.4byte ScrCmd_nop

--- a/data/scripts/hiding_oak.inc
+++ b/data/scripts/hiding_oak.inc
@@ -41,7 +41,7 @@ HidingOak_EventScript_HuntNotStarted::
     end
 
 HidingOak_EventScript_HuntSuccess::
-	playfanfare MUS_OBTAIN_BADGE
+    playfanfare MUS_OBTAIN_BADGE
     buffernumberstring STR_VAR_1, VAR_HIDDEN_OAK_TIMESTAMP_HOURS
     buffernumberstring STR_VAR_2, VAR_HIDDEN_OAK_TIMESTAMP_MINUTES
     buffernumberstring STR_VAR_3, VAR_HIDDEN_OAK_TIMESTAMP_SECONDS

--- a/data/scripts/hiding_oak.inc
+++ b/data/scripts/hiding_oak.inc
@@ -42,6 +42,9 @@ HidingOak_EventScript_HuntNotStarted::
 
 HidingOak_EventScript_HuntSuccess::
 	playfanfare MUS_OBTAIN_BADGE
+    buffernumberstring STR_VAR_1, VAR_HIDDEN_OAK_TIMESTAMP_HOURS
+    buffernumberstring STR_VAR_2, VAR_HIDDEN_OAK_TIMESTAMP_MINUTES
+    buffernumberstring STR_VAR_3, VAR_HIDDEN_OAK_TIMESTAMP_SECONDS
     msgbox HidingOak_Text_HuntSuccess, MSGBOX_SIGN
     return
 
@@ -57,6 +60,7 @@ HidingOak_EventScript_DefeatedOak::
     return
 
 HidingOak_EventScript_SetHuntCompleted::
+    storetimestamp VAR_HIDDEN_OAK_TIMESTAMP_HOURS, VAR_HIDDEN_OAK_TIMESTAMP_MINUTES, VAR_HIDDEN_OAK_TIMESTAMP_SECONDS
     setvar VAR_HIDDEN_OAK_HUNT_STATUS, 3
     return
 

--- a/data/text/hiding_oak.inc
+++ b/data/text/hiding_oak.inc
@@ -5,10 +5,11 @@ HidingOak_Text_HuntNotStarted::
     .string "It's blank$"
 
 HidingOak_Text_HuntSuccess::
-    .string "You win!$"
+    .string "You finished the hunt!\p"
+    .string "Time: {STR_VAR_1}h {STR_VAR_2}m {STR_VAR_3}s$"
 
 HidingOak_Text_HuntFailure::
-    .string "You didn't win ... yet\p"
+    .string "You're not done yet!'\p"
     .string "You've only found {STR_VAR_1} of {STR_VAR_2}$"
 
 HidingOak_Text_NewlyFoundOak::

--- a/include/constants/vars.h
+++ b/include/constants/vars.h
@@ -92,9 +92,9 @@
 #define VAR_HIDDEN_OAK_FLAG_OFFSET         0x402B
 #define VAR_HIDDEN_OAK_HUNT_STATUS         0x402C
 
-#define VAR_0x402D                         0x402D
-#define VAR_0x402E                         0x402E
-#define VAR_0x402F                         0x402F
+#define VAR_HIDDEN_OAK_TIMESTAMP_HOURS     0x402D
+#define VAR_HIDDEN_OAK_TIMESTAMP_MINUTES   0x402E
+#define VAR_HIDDEN_OAK_TIMESTAMP_SECONDS   0x402F
 
 #define VAR_ICE_STEP_COUNT                 0x4030
 #define VAR_STARTER_MON                    0x4031 // 0: Bulbasaur, 1: Squirtle, 2: Charmander

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2273,3 +2273,15 @@ bool8 ScrCmd_setmonmetlocation(struct ScriptContext * ctx)
         SetMonData(&gPlayerParty[partyIndex], MON_DATA_MET_LOCATION, &location);
     return FALSE;
 }
+
+bool8 ScrCmd_storetimestamp(struct ScriptContext * ctx)
+{
+    u16 *ptrHours = GetVarPointer(ScriptReadHalfword(ctx));
+    u16 *ptrMinutes = GetVarPointer(ScriptReadHalfword(ctx));
+    u16 *ptrSeconds = GetVarPointer(ScriptReadHalfword(ctx));
+
+    *ptrHours = gSaveBlock2Ptr->playTimeHours;
+    *ptrMinutes = gSaveBlock2Ptr->playTimeMinutes;
+    *ptrSeconds = gSaveBlock2Ptr->playTimeSeconds;
+    return FALSE;
+}


### PR DESCRIPTION
This stops players leaning on Spacebar and getting faster times by adding in a timestamp that gets logged on defeating the final Oak.